### PR TITLE
Fix issue #50: [Performance] Problème N+1 sur la page etablissements 

### DIFF
--- a/resources/views/admin/etablissement/create.blade.php
+++ b/resources/views/admin/etablissement/create.blade.php
@@ -82,7 +82,7 @@
                                         <option value="suisse">Suisse</option>
                                         <option value="allemagne">Allemagne</option>
                                         <option value="italie">Italie</option>
-                                        <option value="Espagne">Italie</option>
+                                        <option value="espagne">Espagne</option>
                                         <option value="angleterre">Angleterre</option>
                                     </select>
                                 </div>

--- a/resources/views/etablissement/index.blade.php
+++ b/resources/views/etablissement/index.blade.php
@@ -23,11 +23,11 @@
                                         </div>
                                         <div class="sm:ml-2 flex-shrink-0 flex">
                                             <span class="mr-2 px-2 inline-flex text-sm leading-5 font-semibold rounded-full bg-green-100 text-green-800">
-                                                {{ $etablissement->service()->sum('place_disponible') }} disponibles
+                                                {{ $etablissement->place_disponible }} disponibles
                                             </span>
 
                                             <span class="mr-2 px-2 inline-flex text-sm leading-5 font-semibold rounded-full bg-orange-100 text-orange-800">
-                                                {{ $etablissement->service()->sum('place_bientot_disponible') }} prochainement
+                                                {{ $etablissement->place_bientot_disponible }} prochainement
                                             </span>
 
                                         </div>
@@ -57,7 +57,7 @@
                                                 </span>
                                                 <span>
                                                     {{-- <time datetime="2020-01-07">January 7, 2020</time> --}}
-                                                    {{ $etablissement->service()->orderBy('updated_at', 'DESC')->first()->updated_at->diffForHumans() }}
+                                                    {{ Carbon\Carbon::parse($etablissement->updated_at)->diffForHumans() }}
                                                 </span>
                                             @endif
                                         </div>


### PR DESCRIPTION
No more N+1 query -> reduces number of queries from 34 to 8 on a page of 10 etablissements
fix issue #50 

Generated raw query:
```
select `etablissements`.id, ( 6371 * acos( cos( radians(8.4017790) )
         * cos( radians( etablissements.lat ) )
         * cos( radians( etablissements.long )
        - radians(41.8693620) )
        + sin( radians(8.4017790) )
         * sin( radians( etablissements.lat ) ) ) ) AS distance,
        count(services.id) AS nb_services,
        sum(services.place_disponible) AS places_disponibles, sum(services.place_bientot_disponible)  AS places_bientot_disponibles
        from `etablissements`
        LEFT JOIN services ON services.etablissement_id=etablissements.`id`
        GROUP BY etablissements.id  order by `distance` asc limit 10 offset 0
```